### PR TITLE
Adding start delay parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer Kyle Usbeck
 # Trick to get apt-get to not prompt for timezone in tzdata
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG STARTDELAY=5
+ENV STARTDELAY=$STARTDELAY
+
 # Install MAVROS and some other dependencies for later
 RUN apt-get update && apt-get install -y ros-kinetic-mavros ros-kinetic-mavros-extras ros-kinetic-mavros-msgs vim wget screen
 

--- a/README.md
+++ b/README.md
@@ -73,3 +73,19 @@ The [MAVROS page](https://github.com/mavlink/mavros/blob/master/mavros/README.md
  *  TCP client: `tcp://[server_host][:port][/?ids=sysid,compid]`
  *  TCP server: `tcp-l://[bind_host][:port][/?ids=sysid,compid]`
 
+There is a `STARTDELAY` environment variable built into the entry point of the container.
+This will cause the container to sleep before starting.  This is useful for waiting for other 
+microservices to start (gazebo, sitl) in docker-compose or kubernetes when health checks are not an option.
+By default this is 5 seconds.  You can modify it as follows:
+
+No delay:
+
+```
+docker run -it --rm --env FCUURL="tcp://192.168.1.113:5760"  --env STARTDELAY=0 mavros
+```
+
+60 seconds delay:
+
+```
+docker run -it --rm --env FCUURL="tcp://192.168.1.113:5760"  --env STARTDELAY=60 mavros
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,9 @@
 
 FCUURL=$1
 
+printf "Delaying start for $STARTDELAY seconds\n"
+sleep $STARTDELAY
+
 source /opt/ros/kinetic/setup.bash
 roscd mavros
 roslaunch mavros apm2.launch fcu_url:=${FCUURL} 2>&1 > /mavros.log &


### PR DESCRIPTION
Adding a STARTDELAY environment variable built into the entry point of the container. This will cause the container to sleep before starting. This is useful for waiting for other microservices to start (gazebo, sitl) in docker-compose or kubernetes when health checks are not an option. By default this is 5 seconds.

Thanks for putting this together Kyle.
